### PR TITLE
feat(taskfile): add deploy-crossplane task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -387,6 +387,67 @@ tasks:
         exit 0
     silent: false
 
+  deploy-crossplane:
+    desc: Deploy Crossplane (core, providers, functions/configs, provider-configs) via dagger helmfile-operation
+    vars:
+      DAGGER_HELM_MODULE: github.com/stuttgart-things/dagger/helm
+      DAGGER_HELM_MODULE_VERSION: v0.57.0
+      HELM_GIT_REPO: git::https://github.com/stuttgart-things/helm.git
+      KUBECONFIG_FOLDER: ~/.kube
+      ALL_KUBECONFIGS:
+        sh: ls {{ .KUBECONFIG_FOLDER }} | grep -v "^cache$" | xargs -n1 printf '"%s" '
+    cmds:
+      - |
+        set -e
+
+        # SELECT KUBECONFIG
+        SELECTED_KUBECONFIG=$(gum choose {{ .ALL_KUBECONFIGS }})
+        export KUBECONFIG={{ .KUBECONFIG_FOLDER }}/${SELECTED_KUBECONFIG//\"/}
+        echo "SWITCHING TO ${KUBECONFIG}"
+        kubectl get nodes
+
+        gum confirm "Deploy Crossplane to ${KUBECONFIG}?" || exit 0
+
+        apply() {
+          echo "▶ APPLYING: $1"
+          dagger call -m {{ .DAGGER_HELM_MODULE }}@{{ .DAGGER_HELM_MODULE_VERSION }} \
+            helmfile-operation \
+            --operation apply \
+            --helmfile-ref "{{ .HELM_GIT_REPO }}@$1" \
+            --kube-config file://${KUBECONFIG} \
+            --progress plain -vv
+        }
+
+        # 1) CORE — installs Crossplane + package CRDs
+        apply cicd/crossplane.yaml.gotmpl
+        kubectl -n crossplane-system rollout status deploy/crossplane --timeout=180s
+
+        # 2) PROVIDERS — the crossplane-provider-configs release fails on this
+        #    first pass (its ProviderConfig CRDs don't exist until the providers
+        #    are healthy). Expected — reapplied in step 4.
+        apply cicd/crossplane-providers.yaml.gotmpl || echo "⚠ provider-configs expected to fail before CRDs exist — continuing"
+        kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # 3) FUNCTIONS + CONFIGURATIONS — Configurations pull provider-kubernetes
+        #    transitively via dependsOn, which creates the kubernetes.m.crossplane.io CRD.
+        apply cicd/crossplane-config.yaml.gotmpl
+        kubectl wait configuration.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # wait for the transitive provider-kubernetes CRD before reapplying provider-configs
+        echo "Waiting for kubernetes.m.crossplane.io CRD (transitive provider-kubernetes)..."
+        for i in $(seq 1 60); do
+          kubectl get crd clusterproviderconfigs.kubernetes.m.crossplane.io >/dev/null 2>&1 && break
+          sleep 5
+        done
+        kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+        kubectl wait function.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # 4) PROVIDER-CONFIGS — reapply; all ProviderConfig CRDs now exist
+        apply cicd/crossplane-providers.yaml.gotmpl
+
+        echo "✅ CROSSPLANE DEPLOYED"
+        kubectl get provider.pkg.crossplane.io,function.pkg.crossplane.io,configuration.pkg.crossplane.io
+
   do:
     desc: Select a task to run
     cmds:


### PR DESCRIPTION
## Summary

Adds a `deploy-crossplane` task that automates the full Crossplane deployment to a cluster via the dagger helm module (`helmfile-operation`), using the updated `cicd/crossplane*.yaml.gotmpl` helmfiles.

The task encodes the required dependency ordering with health waits (Helmfile, unlike ArgoCD sync-waves, does not wait for package health):

1. **core** — `cicd/crossplane.yaml.gotmpl`, waits for `deploy/crossplane`
2. **providers** — `cicd/crossplane-providers.yaml.gotmpl`; the `crossplane-provider-configs` release is expected to fail on this pass (its ProviderConfig CRDs don't exist until the providers are healthy) and is reapplied in step 4
3. **functions + configurations** — `cicd/crossplane-config.yaml.gotmpl`; Configurations pull `provider-kubernetes` transitively via `dependsOn`, creating the `kubernetes.m.crossplane.io` CRD
4. **provider-configs reapply** — reruns the providers helmfile once all ProviderConfig CRDs exist

Kubeconfig is selected via `gum choose` (from `~/.kube`, same pattern as `install-release`/`uninstall-release`) and guarded by `gum confirm`.

## Notes

- Deploys from the repo default branch (`main`) — the `git::…helm.git@<path>` ref shorthand of the dagger module encodes only the path, not a branch.
- Conventions match existing tasks: dagger `helm@v0.57.0`, `--helmfile-ref "git::…"`, gum-based selection/confirmation.

## Testing

The exact sequence this task encodes was run by hand against a live kind cluster (v1.34.0) — all providers (incl. transitive `provider-kubernetes`), functions, configurations, and provider-configs reached `Healthy`, and the provider pods run under the pinned ServiceAccounts so the cluster-admin ClusterRoleBindings bind correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)