### PR TITLE
fix(ci): repair Analyze-Changed-Charts changed-files step

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,18 +16,29 @@ jobs:
     container:
       image: ghcr.io/stuttgart-things/machineshop/machineshop-9c3178088556daa12a17db5edcc6b5b7:latest
     environment: k8s
+    permissions:
+      contents: read
+      pull-requests: read
     #outputs:
       #collection_folders: ${{ steps.changed-files.outputs.collection_folders }}
     runs-on: kind-testing-runner-1
     steps:
       - name: Get Modified Files by PullRequest
         id: changed-files
+        if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Use the auto-provided workflow token; secrets.GH_TOKEN was empty for
+          # this environment, leaving the API call unauthenticated.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          FILES=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "${{ github.event.pull_request.url }}/files" | \
-          jq -r '.[].filename')
+          # Guard jq against non-array responses (e.g. an API error object),
+          # which previously crashed the step with "Cannot index string".
+          FILES=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ github.event.pull_request.url }}/files" \
+            | jq -r 'if type == "array" then .[].filename else empty end')
+          echo "Changed files:"
+          echo "${FILES}"
 
   yaml-lint:
     name: Lint yaml files


### PR DESCRIPTION
## Summary

Fixes the `Analyze-Changed-Charts` job's "Get Modified Files by PullRequest" step, which failed on every `pull_request` run once the runner came online:

```
env: GITHUB_TOKEN:            ← empty
jq: error (at <stdin>:4): Cannot index string with string "filename"
##[error]Process completed with exit code 5
```

### Root cause
- `secrets.GH_TOKEN` came through **empty** for the `k8s` environment, so `curl` hit the GitHub API unauthenticated and got back an error object (not the files array). `jq -r '.[].filename'` then crashed trying to index a string.
- The step also had no `pull_request` guard (`github.event.pull_request.url` is empty on `push`) and no defense against a non-array response.

### Changes
- Use the auto-provided `github.token` instead of the empty `secrets.GH_TOKEN`, with explicit `contents: read` + `pull-requests: read` permissions.
- Guard `jq` with `if type == "array" then … else empty end` so a bad/empty response no longer crashes the step.
- Run the step only on `pull_request` events and echo the changed files.

### Context
Surfaced while merging #146/#147 after switching CI to the `kind-testing-runner-1` runner — the `push` run passed trivially (empty PR URL → no-op) but the `pull_request` run exposed this long-standing bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)