### PR TITLE
feat(taskfile): add deploy-tekton task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -387,6 +387,51 @@ tasks:
         exit 0
     silent: false
 
+  deploy-tekton:
+    desc: Deploy Tekton (operator + pipeline component) via dagger helmfile-operation
+    vars:
+      DAGGER_HELM_MODULE: github.com/stuttgart-things/dagger/helm
+      DAGGER_HELM_MODULE_VERSION: v0.57.0
+      HELM_GIT_REPO: git::https://github.com/stuttgart-things/helm.git
+      KUBECONFIG_FOLDER: ~/.kube
+      ALL_KUBECONFIGS:
+        sh: ls {{ .KUBECONFIG_FOLDER }} | grep -v "^cache$" | xargs -n1 printf '"%s" '
+    cmds:
+      - |
+        set -e
+
+        # SELECT KUBECONFIG
+        SELECTED_KUBECONFIG=$(gum choose {{ .ALL_KUBECONFIGS }})
+        export KUBECONFIG={{ .KUBECONFIG_FOLDER }}/${SELECTED_KUBECONFIG//\"/}
+        echo "SWITCHING TO ${KUBECONFIG}"
+        kubectl get nodes
+
+        gum confirm "Deploy Tekton to ${KUBECONFIG}?" || exit 0
+
+        # APPLY — installs the Tekton Operator; with autoInstallComponents=false
+        # + enableTektonPipeline=true the chart renders a TektonPipeline CR
+        # (Pipelines only, no Dashboard/Triggers/Chains).
+        echo "▶ APPLYING: cicd/tekton.yaml.gotmpl"
+        dagger call -m {{ .DAGGER_HELM_MODULE }}@{{ .DAGGER_HELM_MODULE_VERSION }} \
+          helmfile-operation \
+          --operation apply \
+          --helmfile-ref "{{ .HELM_GIT_REPO }}@cicd/tekton.yaml.gotmpl" \
+          --kube-config file://${KUBECONFIG} \
+          --progress plain -vv
+
+        # WAIT for operator + the pipeline component to be ready
+        kubectl -n tekton-operator rollout status deploy/tekton-operator --timeout=180s
+        echo "Waiting for TektonPipeline CR to be created by the operator..."
+        for i in $(seq 1 60); do
+          kubectl get tektonpipeline pipeline >/dev/null 2>&1 && break
+          sleep 5
+        done
+        kubectl wait tektonpipeline --all --for=condition=Ready --timeout=300s
+
+        echo "✅ TEKTON DEPLOYED"
+        kubectl get tektonpipeline
+        kubectl -n tekton-pipelines get pods
+
   deploy-crossplane:
     desc: Deploy Crossplane (core, providers, functions/configs, provider-configs) via dagger helmfile-operation
     vars:


### PR DESCRIPTION
## Summary

Adds a `deploy-tekton` task that deploys Tekton to a cluster via the dagger helm module (`helmfile-operation`) from `cicd/tekton.yaml.gotmpl`.

- Applies the helmfile (installs the Tekton Operator).
- Waits for the `tekton-operator` rollout, then polls for the operator-created `TektonPipeline` CR and waits for `condition=Ready`.
- Kubeconfig selected via `gum choose` (from `~/.kube`) and guarded by `gum confirm` — same pattern as `deploy-crossplane`.

## Notes

This helm variant installs **Pipelines only** (chart `autoInstallComponents: false` + `enableTektonPipeline: true` renders a `TektonPipeline` CR, not a full `TektonConfig`/`profile: all`) — no Dashboard/Triggers/Chains. Verified live against a kind cluster (v1.34.0): operator Running, `TektonPipeline/pipeline` v1.3.1 Ready, all `tekton-pipelines` pods Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)