### PR TITLE
refactor(crossplane): split provider-configs into its own helmfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -467,10 +467,9 @@ tasks:
         apply cicd/crossplane.yaml.gotmpl
         kubectl -n crossplane-system rollout status deploy/crossplane --timeout=180s
 
-        # 2) PROVIDERS — the crossplane-provider-configs release fails on this
-        #    first pass (its ProviderConfig CRDs don't exist until the providers
-        #    are healthy). Expected — reapplied in step 4.
-        apply cicd/crossplane-providers.yaml.gotmpl || echo "⚠ provider-configs expected to fail before CRDs exist — continuing"
+        # 2) PROVIDERS — Provider CRs + RBAC only (ProviderConfigs are a
+        #    separate helmfile, applied in step 4 once the CRDs exist).
+        apply cicd/crossplane-providers.yaml.gotmpl
         kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
 
         # 3) FUNCTIONS + CONFIGURATIONS — Configurations pull provider-kubernetes
@@ -478,7 +477,7 @@ tasks:
         apply cicd/crossplane-config.yaml.gotmpl
         kubectl wait configuration.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
 
-        # wait for the transitive provider-kubernetes CRD before reapplying provider-configs
+        # wait for the transitive provider-kubernetes CRD before applying provider-configs
         echo "Waiting for kubernetes.m.crossplane.io CRD (transitive provider-kubernetes)..."
         for i in $(seq 1 60); do
           kubectl get crd clusterproviderconfigs.kubernetes.m.crossplane.io >/dev/null 2>&1 && break
@@ -487,8 +486,8 @@ tasks:
         kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
         kubectl wait function.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
 
-        # 4) PROVIDER-CONFIGS — reapply; all ProviderConfig CRDs now exist
-        apply cicd/crossplane-providers.yaml.gotmpl
+        # 4) PROVIDER-CONFIGS — separate helmfile; all ProviderConfig CRDs now exist
+        apply cicd/crossplane-provider-configs.yaml.gotmpl
 
         echo "✅ CROSSPLANE DEPLOYED"
         kubectl get provider.pkg.crossplane.io,function.pkg.crossplane.io,configuration.pkg.crossplane.io

--- a/cicd/crossplane-provider-configs.yaml.gotmpl
+++ b/cicd/crossplane-provider-configs.yaml.gotmpl
@@ -1,0 +1,62 @@
+---
+environments:
+  default:
+    values:
+      - namespace: crossplane-system
+      # ClusterProviderConfig resources (v2 namespaced *.m.* API surface), all
+      # targeting the local cluster via InjectedIdentity — zero secrets.
+      #
+      # Split out from crossplane-providers.yaml.gotmpl on purpose: these
+      # reference ProviderConfig CRDs that only register once the providers
+      # (and the transitive provider-kubernetes pulled by the Configurations)
+      # are Healthy. Applying them separately — after the providers/config
+      # helmfiles — keeps a single `helmfile apply` of each other helmfile
+      # clean (e.g. when composed in a bundle). The deploy-crossplane task
+      # applies this last.
+      - providerConfigs:
+          helmInCluster:
+            name: in-cluster
+            apiVersion: helm.m.crossplane.io/v1beta1
+            kind: ClusterProviderConfig
+            spec:
+              credentials:
+                source: InjectedIdentity
+          kubernetesInCluster:
+            name: in-cluster
+            apiVersion: kubernetes.m.crossplane.io/v1alpha1
+            kind: ClusterProviderConfig
+            spec:
+              credentials:
+                source: InjectedIdentity
+          # provider-opentofu has no InjectedIdentity mode — every config needs
+          # a configuration block. This ships an empty credentials list + a
+          # kubernetes backend storing state in-cluster (no cloud creds wired).
+          opentofuInCluster:
+            name: in-cluster
+            apiVersion: opentofu.m.upbound.io/v1beta1
+            kind: ClusterProviderConfig
+            spec:
+              credentials: []
+              configuration: |
+                terraform {
+                  backend "kubernetes" {
+                    secret_suffix     = "clusterproviderconfig-in-cluster"
+                    namespace         = "crossplane-system"
+                    in_cluster_config = true
+                  }
+                }
+---
+releases:
+  - name: crossplane-provider-configs
+    installed: true
+    namespace: {{ .Values.namespace }}
+    chart: stuttgart-things/sthings-cluster
+    version: 0.3.20
+    disableValidationOnInstall: true
+    values:
+      - "values/crossplane-provider-configs.values.yaml.gotmpl"
+
+repositories:
+  - name: stuttgart-things
+    url: ghcr.io/stuttgart-things
+    oci: true

--- a/cicd/crossplane-providers.yaml.gotmpl
+++ b/cicd/crossplane-providers.yaml.gotmpl
@@ -26,40 +26,11 @@ environments:
           providerKubeconfig:
             name: provider-kubeconfig
             package: ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.0
-      # ClusterProviderConfig resources (v2 namespaced *.m.* API surface), all
-      # targeting the local cluster via InjectedIdentity — zero secrets.
-      - providerConfigs:
-          helmInCluster:
-            name: in-cluster
-            apiVersion: helm.m.crossplane.io/v1beta1
-            kind: ClusterProviderConfig
-            spec:
-              credentials:
-                source: InjectedIdentity
-          kubernetesInCluster:
-            name: in-cluster
-            apiVersion: kubernetes.m.crossplane.io/v1alpha1
-            kind: ClusterProviderConfig
-            spec:
-              credentials:
-                source: InjectedIdentity
-          # provider-opentofu has no InjectedIdentity mode — every config needs
-          # a configuration block. This ships an empty credentials list + a
-          # kubernetes backend storing state in-cluster (no cloud creds wired).
-          opentofuInCluster:
-            name: in-cluster
-            apiVersion: opentofu.m.upbound.io/v1beta1
-            kind: ClusterProviderConfig
-            spec:
-              credentials: []
-              configuration: |
-                terraform {
-                  backend "kubernetes" {
-                    secret_suffix     = "clusterproviderconfig-in-cluster"
-                    namespace         = "crossplane-system"
-                    in_cluster_config = true
-                  }
-                }
+      # NOTE: the ClusterProviderConfig resources live in the separate
+      # crossplane-provider-configs.yaml.gotmpl — they reference ProviderConfig
+      # CRDs that only register once these providers are Healthy, so keeping
+      # them here would make a single `helmfile apply` fail. Apply this helmfile
+      # first, then crossplane-provider-configs once the providers are up.
 ---
 releases:
   - name: crossplane-providers
@@ -70,17 +41,6 @@ releases:
     disableValidationOnInstall: true
     values:
       - "values/crossplane-providers.values.yaml.gotmpl"
-
-  - name: crossplane-provider-configs
-    installed: true
-    namespace: {{ .Values.namespace }}
-    chart: stuttgart-things/sthings-cluster
-    version: 0.3.20
-    disableValidationOnInstall: true
-    needs:
-      - crossplane-system/crossplane-providers
-    values:
-      - "values/crossplane-provider-configs.values.yaml.gotmpl"
 
 repositories:
   - name: stuttgart-things


### PR DESCRIPTION
## Summary

Splits the Crossplane `ClusterProviderConfig` releases out of `cicd/crossplane-providers.yaml.gotmpl` into a dedicated `cicd/crossplane-provider-configs.yaml.gotmpl`.

**Why:** the ProviderConfig CRDs (`helm.m.`, `kubernetes.m.`, `opentofu.m.`) only register once the providers — and the transitive `provider-kubernetes` pulled by the Configurations — are Healthy. Bundling the ProviderConfigs with the providers meant a single `helmfile apply` always failed on the first pass. Separating them keeps every helmfile apply-clean, which is required to compose them in a central bundle (helmfile `helmfiles:`), and lets the ordering be handled explicitly.

### Changes
- `crossplane-providers.yaml.gotmpl` — now emits **Provider CRs + RBAC only** (DeploymentRuntimeConfig + ClusterRoleBinding). The `providerConfigs` values and the `crossplane-provider-configs` release are removed.
- `crossplane-provider-configs.yaml.gotmpl` (**new**) — emits the 3 `ClusterProviderConfig`s (reuses the existing `values/crossplane-provider-configs.values.yaml.gotmpl`).
- `Taskfile.yaml` `deploy-crossplane` — the providers step is no longer expected to fail; step 4 now applies the new `crossplane-provider-configs.yaml.gotmpl` (instead of reapplying the providers helmfile).

### Testing
Both helmfiles render cleanly via `helmfile template`: `crossplane-providers` emits only Provider/DeploymentRuntimeConfig/ClusterRoleBinding (no ClusterProviderConfig); `crossplane-provider-configs` emits exactly the 3 ClusterProviderConfigs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)