### PR TITLE
chore(cilium): bump chart 1.18.5 -> 1.18.11

### DIFF
--- a/infra/cilium.yaml.gotmpl
+++ b/infra/cilium.yaml.gotmpl
@@ -3,7 +3,7 @@ environments:
   default:
     values:
       - namespace: kube-system
-      - version: 1.18.5
+      - version: 1.18.11
       - configureLB: false
       - deployGateway: false
       - config: kind


### PR DESCRIPTION
Bumps the Cilium chart pin **1.18.5 → 1.18.11** (latest patch on the 1.18 line).

### Why it's safe (checked, no other changes needed)
- **Values** (`infra/values/cilium-kind.values.yaml.gotmpl`): uses only stable keys — `kubeProxyReplacement`, `routingMode: native`, `gatewayAPI`, `l2announcements`, `externalIPs`, `autoDirectNodeRoutes`, `operator.replicas`. All unchanged in 1.18.11.
- **CRDs** (`infra/crds/cilium/kustomization.yaml`): the hand-applied `ciliuml2announcementpolicies` (v2alpha1) and `ciliumloadbalancerippools` (v2) have identical apiVersions/paths in 1.18.11, so no CRD change required.

Verified working on a kind cluster (native routing, kube-proxy replacement, L2 announcements) with 1.18.5; this is a patch-level bump only.

> Alternative: 1.19.5 (newer minor) is also value/CRD-compatible per the same check, but as a minor bump it warrants a `helmfile diff` first — kept this PR to the zero-risk patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)