### PR TITLE
chore: bump bootstrap component versions to latest

### DIFF
--- a/cicd/crossplane-config.yaml.gotmpl
+++ b/cicd/crossplane-config.yaml.gotmpl
@@ -8,12 +8,12 @@ environments:
             name: function-auto-ready
             apiVersion: pkg.crossplane.io/v1beta1
             image: xpkg.crossplane.io/crossplane-contrib/function-auto-ready
-            tag: v0.6.5
+            tag: v0.7.0
           functionGo:
             name: function-go-templating
             apiVersion: pkg.crossplane.io/v1beta1
             image: xpkg.crossplane.io/crossplane-contrib/function-go-templating
-            tag: v0.12.1
+            tag: v0.12.2
           kcl:
             name: function-kcl
             apiVersion: pkg.crossplane.io/v1
@@ -23,12 +23,12 @@ environments:
             name: function-patch-and-transform
             apiVersion: pkg.crossplane.io/v1beta1
             image: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
-            tag: v0.10.6
+            tag: v0.10.7
           environmentConfigs:
             name: function-environment-configs
             apiVersion: pkg.crossplane.io/v1
             image: xpkg.crossplane.io/crossplane-contrib/function-environment-configs
-            tag: v0.7.1
+            tag: v0.7.2
       # Migrated from the decommissioned ghcr.io/stuttgart-things/crossplane/...
       # registry to ghcr.io/stuttgart-things/crossplane-configurations/...
       # (Crossplane v2, namespaced XRs). Entries are re-added one at a time as

--- a/cicd/crossplane-providers.yaml.gotmpl
+++ b/cicd/crossplane-providers.yaml.gotmpl
@@ -15,17 +15,17 @@ environments:
       - providers:
           providerHelm:
             name: provider-helm
-            package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.2.0
+            package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.3.0
             rbac:
               clusterRole: cluster-admin
           providerOpentofu:
             name: provider-opentofu
-            package: xpkg.upbound.io/upbound/provider-opentofu:v1.1.2
+            package: xpkg.upbound.io/upbound/provider-opentofu:v1.1.4
             rbac:
               clusterRole: cluster-admin
           providerKubeconfig:
             name: provider-kubeconfig
-            package: ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.0
+            package: ghcr.io/stuttgart-things/provider-kubeconfig-xpkg:v0.13.1
       # NOTE: the ClusterProviderConfig resources live in the separate
       # crossplane-provider-configs.yaml.gotmpl — they reference ProviderConfig
       # CRDs that only register once these providers are Healthy, so keeping

--- a/cicd/crossplane.yaml.gotmpl
+++ b/cicd/crossplane.yaml.gotmpl
@@ -3,7 +3,7 @@ environments:
   default:
     values:
       - namespace: crossplane-system
-      - version: 2.2.1
+      - version: 2.3.3
       # Providers are installed as Provider CRs (with RBAC) by
       # crossplane-providers.yaml.gotmpl, not via the upstream chart's
       # provider.packages — a passed-through package gets a generated

--- a/infra/cert-manager.yaml.gotmpl
+++ b/infra/cert-manager.yaml.gotmpl
@@ -3,7 +3,7 @@ environments:
   default:
     values:
       - namespace: cert-manager
-      - version: v1.19.2
+      - version: v1.21.0
       - config: selfsigned
       - installCrds: true
 ---

--- a/infra/cilium.yaml.gotmpl
+++ b/infra/cilium.yaml.gotmpl
@@ -3,7 +3,7 @@ environments:
   default:
     values:
       - namespace: kube-system
-      - version: 1.18.11
+      - version: 1.19.5
       - configureLB: false
       - deployGateway: false
       - config: kind

--- a/infra/openebs.yaml.gotmpl
+++ b/infra/openebs.yaml.gotmpl
@@ -9,7 +9,7 @@ environments:
       - openebs_local_lvm_enabled: false
       - openebs_local_zfs_enabled: false
       - openebs_replicated_mayastor_enabled: false
-      - version: 4.2.0
+      - version: 4.5.1
 ---
 releases:
   - name: openebs


### PR DESCRIPTION
Refreshes every component the kind bootstrap (and fleet) pulls from these helmfiles to latest. All chart versions verified resolvable in their upstream repos.

### infra / cicd charts
| Component | From | To |
|---|---|---|
| cilium | 1.18.11 | **1.19.5** |
| cert-manager | v1.19.2 | **v1.21.0** |
| openebs | 4.2.0 | **4.5.1** |
| crossplane | 2.2.1 | **2.3.3** |

### crossplane functions (`cicd/crossplane-config`)
| Function | From | To |
|---|---|---|
| function-auto-ready | v0.6.5 | v0.7.0 |
| function-go-templating | v0.12.1 | v0.12.2 |
| function-patch-and-transform | v0.10.6 | v0.10.7 |
| function-environment-configs | v0.7.1 | v0.7.2 |
| function-kcl | v0.12.1 | _(already latest)_ |

### providers (`cicd/crossplane-providers`)
| Provider | From | To |
|---|---|---|
| provider-helm | v1.2.0 | v1.3.0 |
| provider-opentofu | v1.1.2 | v1.1.4 |
| provider-kubeconfig-xpkg | v0.13.0 | v0.13.1 |

cilium 1.19.5 was previously verified value/CRD-compatible with the kind values (#151 context). Next machinery e2e run will exercise the crossplane/function bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)