### PR TITLE
fix(crossplane-config): pin function-auto-ready back to v0.6.5

### DIFF
--- a/cicd/crossplane-config.yaml.gotmpl
+++ b/cicd/crossplane-config.yaml.gotmpl
@@ -8,7 +8,12 @@ environments:
             name: function-auto-ready
             apiVersion: pkg.crossplane.io/v1beta1
             image: xpkg.crossplane.io/crossplane-contrib/function-auto-ready
-            tag: v0.7.0
+            # Pinned <v0.7.0: the stuttgart-things Configuration packages (namespace,
+            # volume-claim, vspherevm, …) declare dependsOn function-auto-ready
+            # >=v0.6.5,<v0.7.0. Installing v0.7.0 makes those Configurations'
+            # package revisions Unhealthy ("incompatible dependencies"). Bump only
+            # once the Configuration packages widen the constraint.
+            tag: v0.6.5
           functionGo:
             name: function-go-templating
             apiVersion: pkg.crossplane.io/v1beta1


### PR DESCRIPTION
Reverts `function-auto-ready` v0.7.0 → **v0.6.5** (from #152).

The stuttgart-things Configuration packages (`namespace`, `volume-claim`, `vspherevm`, …) declare `dependsOn function-auto-ready >=v0.6.5,<v0.7.0`. #152's minor bump to v0.7.0 crosses that cap, so on a fresh cluster those Configurations' package revisions go **Unhealthy**:

```
cannot resolve package dependencies: incompatible dependencies:
existing package function-auto-ready@v0.7.0 is incompatible with constraint >=v0.6.5,<v0.7.0
```

→ `deploy-crossplane` times out on `kubectl wait configuration --all --for=condition=Healthy`. Verified on a live kind cluster: patching the function back to v0.6.5 makes `namespace`/`volume-claim` Healthy within ~10s.

The other #152 function bumps (go-templating, environment-configs, patch-and-transform) were same-minor patches and are unaffected — left as-is. Re-bump function-auto-ready only once the Configuration packages widen their constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)