### PR TITLE
fix(crossplane-providers): install provider-helm as the dependsOn-derived CR (one CR, not two)

### DIFF
--- a/cicd/crossplane-providers.yaml.gotmpl
+++ b/cicd/crossplane-providers.yaml.gotmpl
@@ -13,9 +13,23 @@ environments:
       #   package metadata, so it needs no binding. provider-kubernetes is not
       #   listed: it is pulled transitively via each Configuration's dependsOn.
       - providers:
+          # provider-helm: name + package deliberately MATCH what the package
+          # manager derives from a Configuration's dependsOn
+          # (xpkg.crossplane.io/crossplane-contrib/provider-helm -> CR name
+          # crossplane-contrib-provider-helm). Configurations here declare that
+          # dependsOn (bootstrap/{platform,flux-init,cni,vault-config}); if this
+          # install used the short name `provider-helm` on xpkg.upbound.io, the
+          # dependsOn would create a SECOND Provider CR and the two would fight
+          # over the releases.helm.m.crossplane.io CRD (the loser stuck
+          # UnhealthyPackageRevision) — verified on a fresh machinery cluster.
+          # Unlike the function-kcl mirror split (functions own no CRDs, so the
+          # pair is benign), providers own CRDs, so there must be exactly ONE
+          # provider-helm CR. Matching the derived name makes the dependsOn find
+          # this CR (which carries the runtimeConfigRef/rbac) instead of adding
+          # its own. See crossplane-configurations#147.
           providerHelm:
-            name: provider-helm
-            package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.3.0
+            name: crossplane-contrib-provider-helm
+            package: xpkg.crossplane.io/crossplane-contrib/provider-helm:v1.3.0
             rbac:
               clusterRole: cluster-admin
           providerOpentofu:


### PR DESCRIPTION
Fixes stuttgart-things/crossplane-configurations#147.

## Problem

`provider-helm` was installed here as CR `provider-helm` from `xpkg.upbound.io`. Four Configurations (`bootstrap/{platform,flux-init,cni,vault-config}`) `dependsOn` provider-helm from `xpkg.crossplane.io`, from which the package manager derives a **second** Provider CR `crossplane-contrib-provider-helm`. Two Provider CRs for the same package (same digest) fight over the `releases.helm.m.crossplane.io` CRD:

```
crossplane-contrib-provider-helm  HEALTHY=False
  UnhealthyPackageRevision: cannot establish control of object:
  releases.helm.m.crossplane.io is already controlled by provider-helm-<digest>
```

That fails the machinery bootstrap's `kubectl wait provider --all --for=condition=Healthy` gate. Verified on a fresh LabUL machinery cluster. `provider-kubernetes` does **not** hit this — it is (deliberately) not installed here and comes solely via `dependsOn`, so there is only one CR.

Unlike the function-kcl cross-mirror pair (functions own no CRDs → benign, per crossplane-configurations CLAUDE.md), **providers own CRDs**, so there must be exactly one provider-helm CR.

## Fix

Name this install `crossplane-contrib-provider-helm` and source it from `xpkg.crossplane.io` — exactly what the `dependsOn` derives. The provider helmfile runs **before** the Configurations, so this CR exists first; the `dependsOn` then finds it (carrying the `runtimeConfigRef` + cluster-admin `DeploymentRuntimeConfig` needed for InjectedIdentity) instead of adding its own. One CR, healthy.

## Blast radius

- `ClusterProviderConfig`s are named `in-cluster`, independent of the provider CR name — nothing referencing the provider by config name changes.
- The `DeploymentRuntimeConfig`, ServiceAccount and ClusterRoleBinding all derive from `$p.name`, so they rename with it, consistently.
- **kind1 is not affected until an explicit re-apply**: no ArgoCD auto-sync, and its `crossplane-providers` release is a one-shot from bootstrap (revision 1, 2026-07-10). A future re-apply moves it to the fixed single-CR state.