### PR TITLE
feat(openebs): make the Loki/MinIO/Alloy observability stack toggleable

### DIFF
--- a/infra/openebs.yaml.gotmpl
+++ b/infra/openebs.yaml.gotmpl
@@ -9,6 +9,21 @@ environments:
       - openebs_local_lvm_enabled: false
       - openebs_local_zfs_enabled: false
       - openebs_replicated_mayastor_enabled: false
+      # The chart ships an observability stack on by default: a Loki
+      # StatefulSet, the MinIO StatefulSet backing it, an Alloy DaemonSet, and
+      # two extra StorageClasses (openebs-loki-localpv, openebs-minio-localpv).
+      # Left ON here so this file changes nothing for existing consumers — it is
+      # unpinned (`git::...helm.git`, no ref), so a default flip would reach
+      # every cluster on its next apply.
+      #
+      # Turn both off on small clusters. On a 1+2 kind cluster the Loki
+      # StatefulSet cannot even schedule: it wants 3 replicas with pod
+      # anti-affinity, the two workers take replicas 1 and 2 and the
+      # control-plane node is tainted, so replica 0 sits Pending forever.
+      # openebs-hostpath — the StorageClass the fleet actually uses — is
+      # unaffected by either toggle.
+      - openebs_loki_enabled: true
+      - openebs_alloy_enabled: true
       - version: 4.5.1
 ---
 releases:

--- a/infra/values/openebs-localpv.values.yaml.gotmpl
+++ b/infra/values/openebs-localpv.values.yaml.gotmpl
@@ -19,3 +19,15 @@ engines:
   replicated:
     mayastor:
       enabled: {{ .Values.openebs_replicated_mayastor_enabled }}
+
+# Observability. `loki.enabled: false` drops BOTH the Loki and the MinIO
+# StatefulSets — MinIO is Loki's object store, a sub-dependency with no toggle
+# of its own — plus the openebs-loki-localpv / openebs-minio-localpv
+# StorageClasses that loki.localpvScConfig emits. `alloy.enabled: false` drops
+# the log-shipper DaemonSet that feeds it; leaving Alloy on with Loki off would
+# ship logs at nothing.
+loki:
+  enabled: {{ .Values.openebs_loki_enabled }}
+
+alloy:
+  enabled: {{ .Values.openebs_alloy_enabled }}


### PR DESCRIPTION
The openebs chart ships an observability stack **enabled by default**: a Loki StatefulSet, the MinIO StatefulSet backing it, an Alloy DaemonSet, and two extra StorageClasses (`openebs-loki-localpv`, `openebs-minio-localpv`). The `localpv` profile disabled the lvm/zfs/mayastor engines but left all of that on, so every consumer of this helmfile got seven pods of logging nobody asked for.

On a small cluster it is worse than unnecessary: the Loki StatefulSet wants **three replicas with pod anti-affinity**, so on a 1+2 kind cluster the two workers take replicas 1 and 2, the control-plane node is tainted, and replica 0 sits `Pending` forever — a permanently non-Running pod that has to be explained to everyone who looks at the cluster. Seen building the u26-kind3 machinery cluster.

## Both toggles default to `true`

Deliberately — this changes nothing for anyone today. This helmfile is consumed **unpinned** (`git::...helm.git`, no ref), so flipping a default would reach every cluster on its next apply rather than when someone chose it.

```bash
helmfile apply -f infra/openebs.yaml.gotmpl \
  --state-values-set openebs_loki_enabled=false,openebs_alloy_enabled=false
```

## Notes

- **MinIO has no toggle of its own** — it is Loki's object store and a sub-dependency, so `loki.enabled=false` is what removes it.
- Alloy is turned off alongside rather than separately by default in callers: leaving the log shipper running with no Loki ships logs at nothing.
- **`openebs-hostpath` is unaffected** by either toggle — verified by rendering the helmfile both ways.

| | default (unchanged) | both toggles off |
|---|---|---|
| StatefulSets | etcd, **loki**, **minio**, nats | etcd, nats |
| DaemonSets | …, **alloy**, … | (alloy gone) |
| StorageClasses | hostpath, single-replica, mayastor-etcd, **loki-localpv**, **minio-localpv** | hostpath, single-replica, mayastor-etcd |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSYX5dsdVdzLCuB6xYhaLK
